### PR TITLE
Fix custom light color assignment

### DIFF
--- a/leadr/roccatleadrconfig/leadr_color_frame.c
+++ b/leadr/roccatleadrconfig/leadr_color_frame.c
@@ -117,34 +117,34 @@ void leadr_color_frame_set_from_rmp(leadrColorFrame *frame, leadrRmp *rmp) {
 }
 
 void leadr_color_frame_update_rmp(leadrColorFrame *frame, leadrRmp *rmp) {
-       leadrColorFramePrivate *priv = frame->priv;
-       leadrRmpLightInfo light_info;
-       GdkColor color;
-       guint i;
-       gboolean use_palette;
+	leadrColorFramePrivate *priv = frame->priv;
+	leadrRmpLightInfo light_info;
+	GdkColor color;
+	guint i;
+	gboolean use_palette;
 
-       use_palette = gtk_roccat_toggle_button_get_active(priv->use_palette);
-       leadr_rmp_set_light_chose_type(rmp, use_palette ? leadr_RMP_LIGHT_CHOSE_TYPE_PALETTE : leadr_RMP_LIGHT_CHOSE_TYPE_CUSTOM);
-       leadr_rmp_set_use_color_for_all(rmp, gtk_roccat_toggle_button_get_active(priv->use_color_for_all));
+	use_palette = gtk_roccat_toggle_button_get_active(priv->use_palette);
+	leadr_rmp_set_light_chose_type(rmp, use_palette ? leadr_RMP_LIGHT_CHOSE_TYPE_PALETTE : leadr_RMP_LIGHT_CHOSE_TYPE_CUSTOM);
+	leadr_rmp_set_use_color_for_all(rmp, gtk_roccat_toggle_button_get_active(priv->use_color_for_all));
 
-       for (i = 0; i < leadr_LIGHTS_NUM; ++i) {
-               if (use_palette) {
-                       light_info = *leadr_rmp_light_info_get_standard(roccat_color_selection_button_get_palette_index(priv->colors[i]));
-                       light_info.state = gtk_roccat_toggle_button_get_active(priv->buttons[i]) ?
-                               leadr_RMP_LIGHT_INFO_STATE_ON : leadr_RMP_LIGHT_INFO_STATE_OFF;
-                       leadr_rmp_set_rmp_light_info(rmp, i, &light_info);
-               } else {
-                       roccat_color_selection_button_get_custom_color(priv->colors[i], &color);
-                       light_info.index = 0; /* palette index unused for custom colors */
-                       light_info.state = gtk_roccat_toggle_button_get_active(priv->buttons[i]) ?
-                               leadr_RMP_LIGHT_INFO_STATE_ON : leadr_RMP_LIGHT_INFO_STATE_OFF;
-                       light_info.red = color.red / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
-                       light_info.green = color.green / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
-                       light_info.blue = color.blue / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
-                       light_info.null = 0;
-                       leadr_rmp_set_custom_light_info(rmp, i, &light_info);
-               }
-       }
+	for (i = 0; i < leadr_LIGHTS_NUM; ++i) {
+		if (use_palette) {
+			light_info = *leadr_rmp_light_info_get_standard(roccat_color_selection_button_get_palette_index(priv->colors[i]));
+			light_info.state = gtk_roccat_toggle_button_get_active(priv->buttons[i]) ?
+			leadr_RMP_LIGHT_INFO_STATE_ON : leadr_RMP_LIGHT_INFO_STATE_OFF;
+			leadr_rmp_set_rmp_light_info(rmp, i, &light_info);
+		} else {
+			roccat_color_selection_button_get_custom_color(priv->colors[i], &color);
+			light_info.index = 0; /* palette index unused for custom colors */
+			light_info.state = gtk_roccat_toggle_button_get_active(priv->buttons[i]) ?
+			leadr_RMP_LIGHT_INFO_STATE_ON : leadr_RMP_LIGHT_INFO_STATE_OFF;
+			light_info.red = color.red / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
+			light_info.green = color.green / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
+			light_info.blue = color.blue / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
+			light_info.null = 0;
+			leadr_rmp_set_custom_light_info(rmp, i, &light_info);
+		}
+	}
 }
 
 GtkWidget *leadr_color_frame_new(void) {

--- a/leadr/roccatleadrconfig/leadr_color_frame.c
+++ b/leadr/roccatleadrconfig/leadr_color_frame.c
@@ -126,14 +126,15 @@ void leadr_color_frame_update_rmp(leadrColorFrame *frame, leadrRmp *rmp) {
 	leadr_rmp_set_use_color_for_all(rmp, gtk_roccat_toggle_button_get_active(priv->use_color_for_all));
 
 	for (i = 0; i < leadr_LIGHTS_NUM; ++i) {
-		roccat_color_selection_button_get_custom_color(priv->colors[i], &color);
-		light_info.index = 0; // FIXME check
-		light_info.state = gtk_roccat_toggle_button_get_active(priv->buttons[i]);
-		light_info.red = color.red / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
-		light_info.green = color.green / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
-		light_info.blue = color.blue / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
-		light_info.null = 0;
-		leadr_rmp_set_custom_light_info(rmp, i, &light_info);
+               roccat_color_selection_button_get_custom_color(priv->colors[i], &color);
+               light_info.index = 0; /* palette index unused for custom colors */
+               light_info.state = gtk_roccat_toggle_button_get_active(priv->buttons[i]) ?
+                       leadr_RMP_LIGHT_INFO_STATE_ON : leadr_RMP_LIGHT_INFO_STATE_OFF;
+               light_info.red = color.red / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
+               light_info.green = color.green / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
+               light_info.blue = color.blue / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
+               light_info.null = 0;
+               leadr_rmp_set_custom_light_info(rmp, i, &light_info);
 
 		light_info = *leadr_rmp_light_info_get_standard(roccat_color_selection_button_get_palette_index(priv->colors[i]));
 		leadr_rmp_set_rmp_light_info(rmp, i, &light_info);

--- a/leadr/roccatleadrconfig/leadr_color_frame.c
+++ b/leadr/roccatleadrconfig/leadr_color_frame.c
@@ -117,28 +117,34 @@ void leadr_color_frame_set_from_rmp(leadrColorFrame *frame, leadrRmp *rmp) {
 }
 
 void leadr_color_frame_update_rmp(leadrColorFrame *frame, leadrRmp *rmp) {
-	leadrColorFramePrivate *priv = frame->priv;
-	leadrRmpLightInfo light_info;
-	GdkColor color;
-	guint i;
+       leadrColorFramePrivate *priv = frame->priv;
+       leadrRmpLightInfo light_info;
+       GdkColor color;
+       guint i;
+       gboolean use_palette;
 
-	leadr_rmp_set_light_chose_type(rmp, gtk_roccat_toggle_button_get_active(priv->use_palette) ? leadr_RMP_LIGHT_CHOSE_TYPE_PALETTE : leadr_RMP_LIGHT_CHOSE_TYPE_CUSTOM);
-	leadr_rmp_set_use_color_for_all(rmp, gtk_roccat_toggle_button_get_active(priv->use_color_for_all));
+       use_palette = gtk_roccat_toggle_button_get_active(priv->use_palette);
+       leadr_rmp_set_light_chose_type(rmp, use_palette ? leadr_RMP_LIGHT_CHOSE_TYPE_PALETTE : leadr_RMP_LIGHT_CHOSE_TYPE_CUSTOM);
+       leadr_rmp_set_use_color_for_all(rmp, gtk_roccat_toggle_button_get_active(priv->use_color_for_all));
 
-	for (i = 0; i < leadr_LIGHTS_NUM; ++i) {
-               roccat_color_selection_button_get_custom_color(priv->colors[i], &color);
-               light_info.index = 0; /* palette index unused for custom colors */
-               light_info.state = gtk_roccat_toggle_button_get_active(priv->buttons[i]) ?
-                       leadr_RMP_LIGHT_INFO_STATE_ON : leadr_RMP_LIGHT_INFO_STATE_OFF;
-               light_info.red = color.red / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
-               light_info.green = color.green / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
-               light_info.blue = color.blue / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
-               light_info.null = 0;
-               leadr_rmp_set_custom_light_info(rmp, i, &light_info);
-
-		light_info = *leadr_rmp_light_info_get_standard(roccat_color_selection_button_get_palette_index(priv->colors[i]));
-		leadr_rmp_set_rmp_light_info(rmp, i, &light_info);
-	}
+       for (i = 0; i < leadr_LIGHTS_NUM; ++i) {
+               if (use_palette) {
+                       light_info = *leadr_rmp_light_info_get_standard(roccat_color_selection_button_get_palette_index(priv->colors[i]));
+                       light_info.state = gtk_roccat_toggle_button_get_active(priv->buttons[i]) ?
+                               leadr_RMP_LIGHT_INFO_STATE_ON : leadr_RMP_LIGHT_INFO_STATE_OFF;
+                       leadr_rmp_set_rmp_light_info(rmp, i, &light_info);
+               } else {
+                       roccat_color_selection_button_get_custom_color(priv->colors[i], &color);
+                       light_info.index = 0; /* palette index unused for custom colors */
+                       light_info.state = gtk_roccat_toggle_button_get_active(priv->buttons[i]) ?
+                               leadr_RMP_LIGHT_INFO_STATE_ON : leadr_RMP_LIGHT_INFO_STATE_OFF;
+                       light_info.red = color.red / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
+                       light_info.green = color.green / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
+                       light_info.blue = color.blue / GDK_ROCCAT_BYTE_TO_COLOR_FACTOR;
+                       light_info.null = 0;
+                       leadr_rmp_set_custom_light_info(rmp, i, &light_info);
+               }
+       }
 }
 
 GtkWidget *leadr_color_frame_new(void) {

--- a/leadr/roccatleadrconfig/leadrconfig_window.c
+++ b/leadr/roccatleadrconfig/leadrconfig_window.c
@@ -150,17 +150,7 @@ static void debug_apply_colors(RoccatDevice *device) {
         g_message("Approach 1: profile save already applied");
         g_usleep(3 * G_USEC_PER_SEC);
 
-        g_message("Approach 2: TalkFX");
-        effect = (ROCCAT_TALKFX_ZONE_AMBIENT << ROCCAT_TALKFX_ZONE_BIT_SHIFT) |
-                 (ROCCAT_TALKFX_EFFECT_ON << ROCCAT_TALKFX_EFFECT_BIT_SHIFT) |
-                 (ROCCAT_TALKFX_SPEED_OFF << ROCCAT_TALKFX_SPEED_BIT_SHIFT);
-        if (!leadr_talkfx(device, effect, cyan_color, cyan_color, &error) && error) {
-                g_message("TalkFX error: %s", error->message);
-                g_clear_error(&error);
-        }
-        g_usleep(3 * G_USEC_PER_SEC);
-
-        g_message("Approach 3: GFX");
+        g_message("Approach 2: GFX");
         leadrGfx *gfx = leadr_gfx_new(device);
         for (i = 0; i < leadr_LIGHTS_NUM; ++i)
                 leadr_gfx_set_color(gfx, i, cyan_color);
@@ -169,6 +159,16 @@ static void debug_apply_colors(RoccatDevice *device) {
                 g_clear_error(&error);
         }
         g_object_unref(gfx);
+        g_usleep(3 * G_USEC_PER_SEC);
+
+        g_message("Approach 3: TalkFX");
+        effect = (ROCCAT_TALKFX_ZONE_AMBIENT << ROCCAT_TALKFX_ZONE_BIT_SHIFT) |
+                 (ROCCAT_TALKFX_EFFECT_ON << ROCCAT_TALKFX_EFFECT_BIT_SHIFT) |
+                 (ROCCAT_TALKFX_SPEED_OFF << ROCCAT_TALKFX_SPEED_BIT_SHIFT);
+        if (!leadr_talkfx(device, effect, cyan_color, cyan_color, &error) && error) {
+                g_message("TalkFX error: %s", error->message);
+                g_clear_error(&error);
+        }
 }
 
 static gboolean save_single(leadrconfigWindow *window, leadrRmp *rmp, guint profile_index, GError **error) {


### PR DESCRIPTION
## Summary
- ensure custom light colors are applied to correct indices on the Leadr device
- use explicit ON/OFF state values when saving custom colors
- align indentation in custom light update loop
- ensure custom color entries always use palette index 0

## Testing
- `cmake -B build` *(fails: Could not find GTK)*

------
https://chatgpt.com/codex/tasks/task_e_6892a2844e4c83268fed5cbcaa41e1ea